### PR TITLE
Multistage dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use Alpine image
-FROM alpine:3.11.3
+FROM alpine:3.11.3 as base
 
 # Install wget + bash
 RUN apk update
@@ -11,8 +11,10 @@ RUN wget https://github.com/boyter/scc/releases/download/v2.12.0/scc-2.12.0-i386
 RUN unzip ./scc-2.12.0-i386-unknown-linux.zip -d /
 RUN chmod +x /scc
 
+FROM alpine:3.11.3
 # Copy shell script
 COPY entrypoint.sh /entrypoint.sh
+COPY from=base /scc /scc
 
 # Run script
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
By applying this commit you remove the unnecessary added extra tools from the docker image you build.  Therefore a base alpine container with only `scc` and your endpoint is left

The old Dockerfile add extra layers - 1: apk update (indices), 2: wget (3: bash I guess you personally want that for some reason?), 4: scc zipped, 5:  another version of scc, without execute permissions

The proposed Dockerfile has two layers on top of alpine,  scc and entrypoint.sh, down form 7.

The improvements make it a faster to download the container for instance in a pipeline. 

You could also remove the entrypoint.sh and just do 
```Dockerfile 
ENTRYPOINT ["/scc"]
```
You could probably even do a (but that will break ci)
```Dockerfile 
FROM scratch 
```
Although you could do a from scratch container on a specific tag, eg. `scratch` for a convenient way to run scc from your pc: `docker run -t -v some/folder:/dir -w /dir iryanbell/scc-docker-action:scratch`
(if you don't want to install it)