### PR TITLE
Update checkout dependency, scc version, and GitHub output mechanism

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,8 @@ RUN apk add wget
 RUN apk add --no-cache --upgrade bash
 
 # Download scc
-RUN wget https://github.com/boyter/scc/releases/download/v2.13.0/scc-2.13.0-x86_64-unknown-linux.zip
-RUN unzip ./scc-2.13.0-x86_64-unknown-linux.zip -d /
+RUN wget https://github.com/boyter/scc/releases/download/v3.1.0/scc_3.1.0_Linux_x86_64.tar.gz
+RUN tar -xf ./scc_3.1.0_Linux_x86_64.tar.gz -C /
 RUN chmod +x /scc
 
 # Copy shell script

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use Alpine image
-FROM alpine:3.11.3
+FROM alpine:3.16.2
 
 # Install wget + bash
 RUN apk update

--- a/README.md
+++ b/README.md
@@ -32,5 +32,7 @@ jobs:
         with:
           args: ${{ env.workspace }} -i js,go,html,css
       - name: Echo scc output
-        run: echo "\n${{ steps.scc.outputs.scc }}"
+        run: |
+          echo
+          echo -n "${{ steps.scc.outputs.scc }}"
 ```

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The lines of ccode.
 
 _.github/workflows/main.yml_
 
-```
+```yaml
 on: [push]
 
 jobs:
@@ -25,10 +25,12 @@ jobs:
     name: A job to count the lines of code.
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Get the lines of code.
         id: scc
-        uses: iryanbell/scc-docker-action@v1.0.2
+        uses: Adapt-API/scc-docker-action@master
         with:
           args: ${{ env.workspace }} -i js,go,html,css
+      - name: Echo scc output
+        run: echo "\n${{ steps.scc.outputs.scc }}"
 ```

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,9 +1,4 @@
 #!/bin/bash
 
 SCC=$(/scc $@)
-
-SCC="${SCC//'%'/'%25'}"
-SCC="${SCC//$'\n'/'%0A'}"
-SCC="${SCC//$'\r'/'%0D'}"
-
 echo "scc=$SCC" >> $GITHUB_OUTPUT

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,4 +6,4 @@ SCC="${SCC//'%'/'%25'}"
 SCC="${SCC//$'\n'/'%0A'}"
 SCC="${SCC//$'\r'/'%0D'}"
 
-echo "name=scc::$SCC" >> $GITHUB_OUTPUT
+echo "scc=$SCC" >> $GITHUB_OUTPUT

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
 
 SCC=$(/scc $@)
-echo "scc=$SCC" >> $GITHUB_OUTPUT
+
+delimiter="$(openssl rand -hex 8)"
+echo "scc<<${delimiter}" >> "${GITHUB_OUTPUT}"
+echo "${SCC}" >> "${GITHUB_OUTPUT}"
+echo "${delimiter}" >> "${GITHUB_OUTPUT}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,4 +6,4 @@ SCC="${SCC//'%'/'%25'}"
 SCC="${SCC//$'\n'/'%0A'}"
 SCC="${SCC//$'\r'/'%0D'}"
 
-echo "::set-output name=scc::$SCC"
+echo "name=scc::$SCC" >> $GITHUB_OUTPUT

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,7 @@
 
 SCC=$(/scc $@)
 
-delimiter="$(openssl rand -hex 8)"
+delimiter="$(date|md5sum)"
 echo "scc<<${delimiter}" >> "${GITHUB_OUTPUT}"
 echo "${SCC}" >> "${GITHUB_OUTPUT}"
 echo "${delimiter}" >> "${GITHUB_OUTPUT}"


### PR DESCRIPTION
This PR applies a handful of changes to the GitHub Action:

- Updates actions/checkout to v3
- Updates to Alpine v3.16.2
- Updates scc to v3.1.0
- Ports the action to utilize `$GITHUB_OUTPUT` versus `set-output` (see https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)
- Utilizes a randomly generated delimiter for multiline output (see https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings)
- Updates the README to output the `scc` report output